### PR TITLE
Fix link to API docs for programmatic router

### DIFF
--- a/data/docs/routing.md
+++ b/data/docs/routing.md
@@ -211,4 +211,4 @@ The above is equivalent to passing a config object manually:
   })
 ```
 
-See also the [API docs for the programmatic router](https://jsr.io/@mastrojs/mastro/doc/server/~/Mastro).
+See also the [API docs for the programmatic router](https://jsr.io/@mastrojs/mastro/doc/server-programmatic/~/Mastro).


### PR DESCRIPTION
Fix the jsr.io link for the programmatic router API docs